### PR TITLE
fix: Explicitly pass config_entry to OptionsFlow constructor

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -209,11 +209,17 @@ class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
-    def async_get_options_flow(config_entry):
-        return OpenAITTSOptionsFlow()
+    def async_get_options_flow(config_entry: ConfigEntry) -> OpenAITTSOptionsFlow: # Added type hint
+        """Get the options flow for this handler."""
+        return OpenAITTSOptionsFlow(config_entry)
 
 class OpenAITTSOptionsFlow(OptionsFlow):
     """Handle options flow for OpenAI TTS."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None: # Added type hint
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
     async def async_step_init(self, user_input: dict | None = None):
         """Handle options flow."""
         errors: dict[str, str] = {}


### PR DESCRIPTION
This change modifies how OpenAITTSOptionsFlow is instantiated by OpenAITTSConfigFlow. The config_entry is now explicitly passed to the OpenAITTSOptionsFlow constructor and stored on the instance.

This is a potential fix for an "Invalid handler specified" error that can occur if the options flow handler is not correctly initialized or registered by Home Assistant.