### PR TITLE
Fix: Correct config flow handler registration

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -9,7 +9,7 @@ import logging
 from urllib.parse import urlparse
 import uuid
 
-from homeassistant import data_entry_flow
+from homeassistant import data_entry_flow, config_entries
 from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.helpers.selector import selector
 from homeassistant.helpers.selector import (
@@ -99,7 +99,8 @@ def get_chime_options() -> list[dict[str, str]]:
     options.sort(key=lambda x: x["label"])
     return options
 
-class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
+@config_entries.HANDLERS.register(DOMAIN)
+class OpenAITTSConfigFlow(ConfigFlow):
     """Handle a config flow for OpenAI TTS."""
     VERSION = 1
     # Connection class and data not needed for this version of config flow


### PR DESCRIPTION
Changed the config flow registration in `custom_components/openai_tts/config_flow.py` to use the `@config_entries.HANDLERS.register(DOMAIN)` decorator.

This resolves the 'Invalid handler specified' error that occurred when you tried to add the integration, by ensuring Home Assistant can correctly load and associate the config flow handler with the 'openai_tts' domain.