### PR TITLE
Fix: Align config flow handler with HA documentation

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -9,8 +9,8 @@ import logging
 from urllib.parse import urlparse
 import uuid
 
-from homeassistant import data_entry_flow, config_entries
-from homeassistant.config_entries import ConfigFlow, OptionsFlow
+from homeassistant import data_entry_flow
+from homeassistant.config_entries import ConfigFlow, OptionsFlow, ConfigEntry
 from homeassistant.helpers.selector import selector
 from homeassistant.helpers.selector import (
     TextSelector,
@@ -99,8 +99,7 @@ def get_chime_options() -> list[dict[str, str]]:
     options.sort(key=lambda x: x["label"])
     return options
 
-@config_entries.HANDLERS.register(DOMAIN)
-class OpenAITTSConfigFlow(ConfigFlow):
+class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OpenAI TTS."""
     VERSION = 1
     # Connection class and data not needed for this version of config flow


### PR DESCRIPTION
Reverted the config flow registration in `custom_components/openai_tts/config_flow.py` to use `class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN)`. This is the method specified in the official Home Assistant developer documentation.

The previous attempt used a decorator, which was incorrect. This change should resolve the 'Invalid handler specified' error by ensuring Home Assistant correctly loads and associates the config flow handler.