### PR TITLE
Fix: Resolve AttributeError for Kokoro config flow

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -212,7 +212,6 @@ class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
         elif current_engine == KOKORO_FASTAPI_ENGINE:
             data_schema_engine.update({
                 vol.Required(CONF_KOKORO_URL, default=user_input.get(CONF_KOKORO_URL) if user_input else KOKORO_DEFAULT_URL): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
-                vol.Required(CONF_MODEL, default=KOKORO_MODEL): cv.disabled(KOKORO_MODEL),
                 vol.Required(CONF_VOICE, default=user_input.get(CONF_VOICE, KOKORO_VOICES[0]) if user_input else KOKORO_VOICES[0]): cv.string,
             })
 


### PR DESCRIPTION
Removes the use of `cv.disabled` for `CONF_MODEL` in the Kokoro engine's schema in `config_flow.py`. This was causing an `AttributeError: module 'homeassistant.helpers.config_validation' has no attribute 'disabled'`, which led to an 'Unknown error occurred' when you tried to configure the Kokoro engine.

The `CONF_MODEL` for Kokoro is fixed and is correctly set in the entry data internally; it does not need to be part of the user-editable form for this step.

This change should allow the Kokoro engine configuration to proceed without error.