### PR TITLE
Feat: Change Kokoro voice input to dropdown selector

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -212,7 +212,14 @@ class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
         elif current_engine == KOKORO_FASTAPI_ENGINE:
             data_schema_engine.update({
                 vol.Required(CONF_KOKORO_URL, default=user_input.get(CONF_KOKORO_URL) if user_input else KOKORO_DEFAULT_URL): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
-                vol.Required(CONF_VOICE, default=user_input.get(CONF_VOICE, KOKORO_VOICES[0]) if user_input else KOKORO_VOICES[0]): cv.string,
+                vol.Required(CONF_VOICE, default=user_input.get(CONF_VOICE, KOKORO_VOICES[0]) if user_input else KOKORO_VOICES[0]): selector({
+                    "select": {
+                        "options": KOKORO_VOICES,
+                        "mode": "dropdown",
+                        "sort": True,
+                        "custom_value": False
+                    }
+                }),
             })
 
         # Common field for both engines - Speed


### PR DESCRIPTION
I modified the config flow for the Kokoro TTS engine to use a dropdown selector for voice selection (`CONF_VOICE`) instead of a plain text field.

This uses the `KOKORO_VOICES` list from `const.py` and improves usability by allowing you to select from a predefined list.