### PR TITLE
Fix errors in OpenAI TTS options flow

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -251,7 +251,8 @@ class OpenAITTSOptionsFlow(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None: # Added type hint
         """Initialize options flow."""
-        self.config_entry = config_entry
+        # self.config_entry is automatically available from the base OptionsFlow class
+        pass
 
     async def async_step_init(self, user_input: dict | None = None):
         """Handle options flow."""
@@ -300,8 +301,6 @@ class OpenAITTSOptionsFlow(OptionsFlow):
                     CONF_VOICE,
                     default=self.config_entry.options.get(CONF_VOICE, self.config_entry.data.get(CONF_VOICE, KOKORO_VOICES[0]))
                 )] = vol.In(KOKORO_VOICES)
-
-            options_schema_dict[vol.Optional(CONF_MODEL, default=KOKORO_MODEL)] = cv.disabled(KOKORO_MODEL)
 
         else: # OpenAI
             options_schema_dict.update({


### PR DESCRIPTION
This commit addresses two issues preventing the options flow from working correctly:

1.  **AttributeError for cv.disabled:** Removed the usage of `cv.disabled(KOKORO_MODEL)` in the options flow for the Kokoro engine. This function call was causing an `AttributeError: module 'homeassistant.helpers.config_validation' has no attribute 'disabled'`, which prevented the options flow from loading. The fixed Kokoro model does not need to be displayed as a disabled form field in the options.

2.  **Deprecation of self.config_entry assignment:** Removed the line `self.config_entry = config_entry` from the `__init__` method of `OpenAITTSOptionsFlow`. This explicit assignment is deprecated as `self.config_entry` is already provided by the base `OptionsFlow` class. This change silences the related deprecation warning.

These fixes should allow you to successfully load the 'Configure' screen for the OpenAI TTS integration and adjust options for both OpenAI and Kokoro engines, including Kokoro's chunk size and voice blending settings.