### PR TITLE
feat: Implement TTS streaming via media_source for Kokoro

### DIFF
--- a/custom_components/openai_tts/tests/test_tts.py
+++ b/custom_components/openai_tts/tests/test_tts.py
@@ -20,12 +20,19 @@ from custom_components.openai_tts.const import (
     OPENAI_ENGINE,
     KOKORO_FASTAPI_ENGINE,
     CONF_KOKORO_URL,
-    KOKORO_MODEL, # Added
+    KOKORO_MODEL,
     UNIQUE_ID,
-    CONF_KOKORO_CHUNK_SIZE, # Added
-    DEFAULT_KOKORO_CHUNK_SIZE, # Added
+    CONF_KOKORO_CHUNK_SIZE,
+    DEFAULT_KOKORO_CHUNK_SIZE,
+    CONF_CHIME_ENABLE, # Added for testing warning
+    CONF_NORMALIZE_AUDIO, # Added for testing warning
     # CONF_KOKORO_VOICE_ALLOW_BLENDING not directly tested here, but in config_flow tests
 )
+from homeassistant.components import media_source # Added
+import hashlib # Added
+from urllib.parse import quote # Added
+from custom_components.openai_tts.tts import STREAMING_VIEW_URL # Added
+
 
 # Minimal HomeAssistant mock
 class MockHomeAssistant(MagicMock):
@@ -211,6 +218,70 @@ class TestOpenAITTSEntity(unittest.IsolatedAsyncioTestCase):
         await entity.async_will_remove_from_hass()
         self.mock_engine.close.assert_called_once()
 
+    @patch('custom_components.openai_tts.tts.get_url') # Mock get_url
+    @patch('custom_components.openai_tts.tts._LOGGER') # Mock logger
+    async def test_async_get_tts_audio_media_source_requested(self, mock_logger, mock_get_url):
+        """Test get_tts_audio returns PlayMedia when media_source option is true."""
+        mock_get_url.return_value = "http://hass_base_url" # Mock base URL
+
+        entity = self._setup_entity(self.openai_config_data)
+        entity.entity_id = "tts.test_openai_tts_entity" # Set a mock entity_id for URL generation
+
+        message = "Hello streaming world"
+        options = {media_source.TTS_SPEAK_OPTIONS_KEY_MEDIA_SOURCE_ID: True}
+
+        # Mock engine's get_tts to avoid actual API call, not strictly needed for URL gen but good practice
+        async def dummy_audio_stream(*args, **kwargs):
+            yield b"dummy"
+        self.mock_engine.get_tts = dummy_audio_stream
+
+        result = await entity.async_get_tts_audio(message, "en-US", options=options)
+
+        self.assertIsInstance(result, media_source.PlayMedia)
+        self.assertEqual(result.mime_type, "audio/mpeg")
+
+        message_hash = hashlib.sha256(message.encode("utf-8")).hexdigest()[:16]
+        expected_path = STREAMING_VIEW_URL.format(entity_id=entity.entity_id, message_hash=message_hash)
+        expected_url = f"http://hass_base_url{expected_path}?message={quote(message)}"
+        self.assertEqual(result.url, expected_url)
+
+        # Test warning log if chime or normalization is enabled
+        entity._config.options = {CONF_CHIME_ENABLE: True}
+        await entity.async_get_tts_audio(message, "en-US", options=options)
+        mock_logger.warning.assert_called_with(
+            "Chime and/or normalization are enabled but will be bypassed for media_source streaming."
+        )
+        mock_logger.reset_mock() # Reset for next assertion
+
+        entity._config.options = {CONF_NORMALIZE_AUDIO: True}
+        await entity.async_get_tts_audio(message, "en-US", options=options)
+        mock_logger.warning.assert_called_with(
+            "Chime and/or normalization are enabled but will be bypassed for media_source streaming."
+        )
+
+    async def test_async_get_tts_audio_fallback_to_bytes(self):
+        """Test get_tts_audio falls back to returning bytes when media_source is not requested."""
+        entity = self._setup_entity(self.openai_config_data)
+
+        test_audio_chunks = [b"Hello", b" ", b"World"]
+        async def mock_stream_audio(*args, **kwargs):
+            for chunk in test_audio_chunks:
+                yield chunk
+        self.mock_engine.get_tts = mock_stream_audio
+
+        # Case 1: media_source.TTS_SPEAK_OPTIONS_KEY_MEDIA_SOURCE_ID is False
+        options_false = {media_source.TTS_SPEAK_OPTIONS_KEY_MEDIA_SOURCE_ID: False}
+        fmt, audio_data = await entity.async_get_tts_audio("Test message", "en-US", options=options_false)
+        self.assertEqual(fmt, "mp3")
+        self.assertEqual(audio_data, b"Hello World")
+
+        # Case 2: media_source.TTS_SPEAK_OPTIONS_KEY_MEDIA_SOURCE_ID is not in options
+        options_absent = {}
+        fmt_absent, audio_data_absent = await entity.async_get_tts_audio("Test message", "en-US", options=options_absent)
+        self.assertEqual(fmt_absent, "mp3")
+        self.assertEqual(audio_data_absent, b"Hello World")
+
+
     @patch('custom_components.openai_tts.tts.OpenAITTSEngine')
     async def test_async_setup_entry_kokoro_with_chunk_size_option(self, MockOpenAITTSEngineConstructor):
         """Test async_setup_entry for Kokoro with chunk_size in options."""
@@ -286,6 +357,138 @@ class TestOpenAITTSEntity(unittest.IsolatedAsyncioTestCase):
             url=self.openai_config_data[CONF_URL]
         )
         async_add_entities_mock.assert_called_once()
+
+# Need aiohttp.web for mocking request/response in view tests
+import aiohttp.web
+
+# Test class for the OpenAITTSStreamingView
+class TestOpenAITTSStreamingView(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.hass = MockHomeAssistant()
+        self.mock_engine = AsyncMock(spec=OpenAITTSEngine)
+
+        self.mock_config_entry = MagicMock(spec=ConfigEntry)
+        # Provide default data and options that the view might access
+        self.mock_config_entry.data = {
+            CONF_VOICE: "alloy", # Default voice from data
+            CONF_SPEED: 1.0,   # Default speed from data
+            # Add other fields if your view's logic depends on them from data
+        }
+        self.mock_config_entry.options = {
+            # Options can override data, e.g., if user configured differently
+            # CONF_VOICE: "echo",
+            # CONF_SPEED: 1.2,
+        }
+
+
+        from custom_components.openai_tts.tts import OpenAITTSStreamingView # Import here
+        self.view = OpenAITTSStreamingView(self.hass, self.mock_engine, self.mock_config_entry)
+
+    async def test_view_get_successful_stream(self):
+        """Test successful streaming from the view."""
+        test_audio_chunks = [b"chunk1", b"chunk2", b"chunk3"]
+
+        # Configure the mock engine to return our test chunks
+        async def mock_engine_tts_stream(*args, **kwargs):
+            for chunk in test_audio_chunks:
+                yield chunk
+        self.mock_engine.get_tts = mock_engine_tts_stream
+
+        # Mock aiohttp.web.Request
+        mock_request = MagicMock(spec=aiohttp.web.Request)
+        mock_request.query = {"message": "Test stream message"} # Message passed via query
+
+        # Mock aiohttp.web.StreamResponse
+        # We need to mock its methods like prepare, write, write_eof
+        mock_stream_response_instance = AsyncMock(spec=aiohttp.web.StreamResponse)
+        mock_stream_response_instance.headers = {} # Initialize headers attribute
+
+        # Patch the StreamResponse constructor to return our mock instance
+        with patch("aiohttp.web.StreamResponse", return_value=mock_stream_response_instance) as MockStreamResponseCls:
+
+            response_from_view = await self.view.get(mock_request, "test_entity_id", "test_message_hash")
+
+            MockStreamResponseCls.assert_called_once() # Verify constructor was called
+
+            # Check headers set on the response instance
+            self.assertEqual(mock_stream_response_instance.content_type, "audio/mpeg")
+            self.assertEqual(mock_stream_response_instance.headers['Cache-Control'], 'no-cache, no-store, must-revalidate')
+
+            # Check methods called on the response instance
+            mock_stream_response_instance.prepare.assert_called_once_with(mock_request)
+
+            self.assertEqual(mock_stream_response_instance.write.call_count, len(test_audio_chunks))
+            for i, chunk in enumerate(test_audio_chunks):
+                self.assertEqual(mock_stream_response_instance.write.call_args_list[i][0][0], chunk)
+
+            mock_stream_response_instance.write_eof.assert_called_once()
+            self.assertEqual(response_from_view, mock_stream_response_instance)
+
+    async def test_view_get_missing_message_parameter(self):
+        """Test view response when 'message' query parameter is missing."""
+        mock_request = MagicMock(spec=aiohttp.web.Request)
+        mock_request.query = {} # 'message' parameter is missing
+
+        # We expect a plain aiohttp.web.Response, not StreamResponse, for this error
+        with patch("aiohttp.web.Response", spec=aiohttp.web.Response) as MockPlainResponseCls:
+            # Call the view's get method
+            await self.view.get(mock_request, "test_entity_id", "test_message_hash")
+            # Assert that aiohttp.web.Response was called with status 400
+            MockPlainResponseCls.assert_called_once_with(status=400, text="Missing 'message' query parameter")
+
+    @patch('custom_components.openai_tts.tts._LOGGER')
+    async def test_view_get_engine_error_before_stream_prepare(self, mock_logger):
+        """Test view handling when the TTS engine raises an error before stream preparation."""
+        self.mock_engine.get_tts.side_effect = HomeAssistantError("Engine TTS pre-stream failure")
+
+        mock_request = MagicMock(spec=aiohttp.web.Request)
+        mock_request.query = {"message": "Test error case"}
+
+        # Mock StreamResponse, but its methods shouldn't be called if error is early
+        mock_stream_response_instance = AsyncMock(spec=aiohttp.web.StreamResponse)
+        mock_stream_response_instance.headers = {}
+        mock_stream_response_instance.prepared = False # Simulate headers not yet sent
+
+        with patch("aiohttp.web.StreamResponse", return_value=mock_stream_response_instance):
+            # We expect the HomeAssistantError to propagate if it happens before response.prepare
+            # Or, if the view catches it and returns a 500, we'd test for that.
+            # Based on current view code, it re-raises if response.prepared is False.
+            with self.assertRaises(HomeAssistantError):
+                 await self.view.get(mock_request, "test_entity_id", "test_message_hash")
+
+            mock_logger.exception.assert_called() # Check that an error was logged
+            mock_stream_response_instance.prepare.assert_not_called() # Stream should not have been prepared
+
+    @patch('custom_components.openai_tts.tts._LOGGER')
+    async def test_view_get_cancelled_error_during_streaming(self, mock_logger):
+        """Test view handling for CancelledError during streaming."""
+        # Simulate CancelledError after some chunks have been sent
+        test_audio_chunks = [b"chunk1", b"cancelled_after_this"]
+        async def mock_engine_tts_cancel(*args, **kwargs):
+            yield test_audio_chunks[0]
+            yield test_audio_chunks[1]
+            raise asyncio.CancelledError("Stream cancelled by client")
+        self.mock_engine.get_tts = mock_engine_tts_cancel
+
+        mock_request = MagicMock(spec=aiohttp.web.Request)
+        mock_request.query = {"message": "Test cancellation"}
+
+        mock_stream_response_instance = AsyncMock(spec=aiohttp.web.StreamResponse)
+        mock_stream_response_instance.headers = {}
+
+        with patch("aiohttp.web.StreamResponse", return_value=mock_stream_response_instance):
+            with self.assertRaises(asyncio.CancelledError): # Expect CancelledError to propagate
+                await self.view.get(mock_request, "test_entity_id", "test_message_hash")
+
+            mock_stream_response_instance.prepare.assert_called_once_with(mock_request)
+            # Check that write was called for chunks before cancellation
+            self.assertEqual(mock_stream_response_instance.write.call_count, len(test_audio_chunks))
+            mock_stream_response_instance.write_eof.assert_not_called() # EOF should not be sent
+            mock_logger.debug.assert_called_with(
+                "Streaming TTS request cancelled by client for entity_id: %s, message_hash: %s",
+                "test_entity_id", "test_message_hash"
+            )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds support for streaming Text-to-Speech (TTS) audio to compatible media players (e.g., ESPHome voice assistants) by leveraging Home Assistant's media_source functionality.

Key changes:
- Modified OpenAITTSEntity to return a media_source.PlayMedia object when the appropriate option is provided in the service call. This object contains a URL that clients can stream audio from.
- Introduced OpenAITTSStreamingView, a new HTTP view that handles requests to these streaming URLs. This view fetches audio chunks from the TTS engine (e.g., Kokoro-FastAPI) and streams them directly to the client.
- When streaming via media_source, ffmpeg-based post-processing (chimes, audio normalization) is bypassed to enable true end-to-end streaming. A warning is logged if these features are enabled during a streaming request.
- Added unit tests for the new streaming entity logic and the HTTP streaming view, covering successful streaming, error handling, and request cancellation.

This allows for lower latency TTS playback on devices that support streaming from a URL, by avoiding the need for the Home Assistant server to download the entire audio file before playback can begin.