### PR TITLE
refactor: Update repo URLs and name to davidtorcivia/kokoro_openai_tts

### DIFF
--- a/custom_components/openai_tts/manifest.json
+++ b/custom_components/openai_tts/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "openai_tts",
-  "name": "OpenAI TTS",
+  "name": "Kokoro OpenAI TTS",
   "codeowners": [
-    "@sfortis"
+    "@davidtorcivia"
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/sfortis/openai_tts/",
+  "documentation": "https://github.com/davidtorcivia/kokoro_openai_tts/",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/sfortis/openai_tts/issues",
+  "issue_tracker": "https://github.com/davidtorcivia/kokoro_openai_tts/issues",
   "requirements": [],
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/custom_components/openai_tts/tts.py
+++ b/custom_components/openai_tts/tts.py
@@ -241,8 +241,8 @@ class OpenAITTSEntity(TextToSpeechEntity):
         options = options or {}
 
         _LOGGER.debug(" -------------------------------------------")
-        _LOGGER.debug("|  OpenAI TTS                               |")
-        _LOGGER.debug("|  https://github.com/sfortis/openai_tts    |")
+        _LOGGER.debug("|  Kokoro OpenAI TTS                        |")
+        _LOGGER.debug("|  https://github.com/davidtorcivia/kokoro_openai_tts |")
         _LOGGER.debug(" -------------------------------------------")
 
         try:


### PR DESCRIPTION
- Changed 'name' in manifest.json to 'Kokoro OpenAI TTS'.
- Updated 'codeowners', 'documentation', and 'issue_tracker' URLs in manifest.json to point to the davidtorcivia/kokoro_openai_tts repository.
- Incremented version in manifest.json to 0.3.3.
- Updated repository URLs in README.md HACS installation instructions.
- Updated repository URL in tts.py debug log header.